### PR TITLE
Allow use with grub-efi-amd64 (Closes: #680717)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: http://git.grml.org/?p=grml-rescueboot.git
 
 Package: grml-rescueboot
 Architecture: all
-Depends: grub-pc, ${shlibs:Depends}, ${misc:Depends}
+Depends: grub-pc | grub-efi-amd64, ${shlibs:Depends}, ${misc:Depends}
 Description: Integrates Grml ISO booting into GRUB
  This package provides a script for update-grub which looks for
  Grml ISO images in /boot/grml and automatically adds an entry


### PR DESCRIPTION
I didn't consider grub-efi-ia32 because I can't actually test it, and
likely there is almost no hardware that would benefit from this.

64bit EFI grub works for me.
