### PR TITLE
Fix relative path detection of ISO files

### DIFF
--- a/42_grml.orig
+++ b/42_grml.orig
@@ -86,10 +86,17 @@ for file in "${ISO_LOCATION}"/*.iso ; do
      fi
 done
 
+<<<<<<< HEAD:42_grml
 for grmliso in $iso_list ; do
-  rel_dirname="$(dirname $(make_system_path_relative_to_its_root $grmliso))"
+  rel_dirname="$(make_system_path_relative_to_its_root $(dirname $grmliso))"
   grml="$(basename $grmliso)"
   device="$(${grub_probe} -t device ${grmliso})"
+=======
+for iso in $iso_list ; do
+  rel_dirname="$(dirname $(make_system_path_relative_to_its_root $iso))"
+  isofn="$(basename $iso)"
+  device="$(${grub_probe} -t device ${iso})"
+>>>>>>> 22ded3f... Fix relative path detection of ISO files:42_loopback-iso
 
   additional_param=""
 
@@ -112,11 +119,19 @@ for grmliso in $iso_list ; do
   cat << EOF
 menuentry "${title}" {
 ${grub_prep}
-        iso_path="${rel_dirname%/}/${grml}"
+<<<<<<< HEAD:42_grml
+        iso_path="${rel_dirname}/${grml}"
         export iso_path
         kernelopts=" $CUSTOM_BOOTOPTIONS $additional_param "
         export kernelopts
-        loopback loop "${rel_dirname%/}/$grml"
+        loopback loop "${rel_dirname}/$grml"
+=======
+        iso_path="${rel_dirname%/}/${isofn}"
+        export iso_path
+        kernelopts=" $CUSTOM_BOOTOPTIONS $additional_param "
+        export kernelopts
+        loopback loop "${rel_dirname%/}/$isofn"
+>>>>>>> 22ded3f... Fix relative path detection of ISO files:42_loopback-iso
         set root=(loop)
         configfile /boot/grub/loopback.cfg
 }


### PR DESCRIPTION
The problem becomes apparent when using symbolic links in `$ISO_LOCATION`
that point to ISO files on another partition.

Calling `make_system_path_relative_to_its_root` not on the dirname but on
the ISO file fixes this. Also avoid a double slash (`//`...) in `$iso_path`
when `$rel_dirname` is just the root dir of that other partition (`/`).