### PR TITLE
Unload tpm module to support booting ISOs with GRUB 2.04 on UEFI systems

### DIFF
--- a/42_grml
+++ b/42_grml
@@ -116,6 +116,8 @@ ${grub_prep}
         export iso_path
         kernelopts=" $CUSTOM_BOOTOPTIONS $additional_param "
         export kernelopts
+        # support booting recent GRUB versions on UEFI systems
+        rmmod tpm
         loopback loop "${rel_dirname%/}/$grml"
         set root=(loop)
         configfile /boot/grub/loopback.cfg


### PR DESCRIPTION
See https://help.ubuntu.com/community/Grub2/ISOBoot#Menuentry_Example

Closes: #975835
Thanks: Vasek Opekar <opekar@eccam.com> for the bug report