### PR TITLE
FIX encpasswd value is ignored

### DIFF
--- a/etc/default/grml-rescueboot
+++ b/etc/default/grml-rescueboot
@@ -5,4 +5,4 @@
 
 # To set any specific bootoptions for rescue images
 # present in /boot/grml just set and enable the following option:
-# CUSTOM_BOOTOPTIONS="ssh=password lang=de"
+# CUSTOM_BOOTOPTIONS='ssh=password lang=de'


### PR DESCRIPTION
when using double quotes, the contents are parsed. This will break any hashes for `encpasswd` that contain `$` when `42_grml` (grub-mkconfig helper script for Grml rescue systems) is executed