### PR TITLE
Fix booting from mdadm raid.

### DIFF
--- a/42_grml
+++ b/42_grml
@@ -98,6 +98,11 @@ for grmliso in $iso_list ; do
       dependencies=$(get_dependencies ${device})
       dep_string=""
       for dep in $dependencies $device ; do
+        case "$dep" in
+          /dev/md*)
+          md_name="$(mdadm --detail --export "$dep" | sed -ne 's/MD_NAME=//p')"
+          dep="/dev/md/$md_name"
+        esac
         dep_string="$dep_string,$dep"
       done
       dep_string=${dep_string#,}


### PR DESCRIPTION
Hi.

As subject states, grml can't boot from (local) mdadm raid.

The reason is simple: because hostname in initramfs (it's empty) does not match with the hostname of installed system, mdadm assembles arrays with different names, and there's no md device, which `42_grub` has added to `live-media=`.  E.g. when installed system has `/dev/md/0` and hostname "debian11", mdadm from initramfs creates `/dev/md126` and symlink `/dev/md/debian11:0`, but neither of them matches with `/dev/md0` added into `live-media=` by `42_grub`.

I've tried (too) many workarounds, but none of them worked:
- adding `live-media=` to `CUSTOM_BOOTOPTIONS` does not work, because `42_grub` creates another one and effectively overwrites it.
- `ip=` and (grml's) `hostname=` kernel command-line option works too late, after `mountroot` stage at which initrd tries to assemble raid, so can't help.
- Neither works `md=` kernel option, which seems used for older mdadm metadata formats and now ignored completely.
- Nor (surprisingly) adding fixed `mdadm.conf` (with `HOMEHOST <ignore>` or `HOMEHOST real_hostname`) to initramfs. This one because with `boot=live` initramfs deletes `mdadm.conf` (in `check_dev()` function from `lib/live/boot/9990-misc-helpers.sh`) before calling to `scripts/local-block/mdadm` (well, the reason is explained there and seems reasonable).

So, patching `42_grub` seems the only way.

There're probably two ways of fixing this: allowing to overwrite `live-media=` in `CUSTOM_BOOTOPTIONS` or just fixing autodetected mdadm array name. Here is implementation of the second one.