### PR TITLE
Fix '-f' option and getopts optstring.

### DIFF
--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -34,7 +34,7 @@ usage() {
   echo "Usage: $(basename "$0") [-f] [-a <32|64|96>] [-t <small|full>]"
 }
 
-while getopts ":a::t::f:h" opt ; do
+while getopts ":a:t:fh" opt ; do
   case ${opt} in
     a)
       if [ "${OPTARG}" = 32 ] || [ "${OPTARG}" = 64 ] || [ "${OPTARG}" = 96 ] ; then


### PR DESCRIPTION
There're a few problems with current optstring:
1. Option `-f` does not need an argument. So, there should not be any colon after `f`. And this is the reason, why e.g. `update-grml-rescueboot -f -t small` will mistakenly download `full` iso: option `-f` eats `-t` as an argument.
2. Though options `-a` and `-t` defined in optstring as having optional argument, in fact, require argument in code: `else` branch produces an error and there's no check for empty `OPTARG`.
3. And, finally, shell `getopts` does not support optional arguments (double colon in optstring) at all. So, to make point 2 even possible argument parsing should be rewritten somehow..

But i think it's simpler to just make `-a` and `-t` arguments to be required, and here is the fix.