### PR TITLE
Support new ISO names

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Vcs-Browser: https://github.com/grml/grml-rescueboot
 Package: grml-rescueboot
 Architecture: all
 Depends:
- grub-pc | grub-efi-amd64,
+ grub2-common,
  ${misc:Depends},
  ${shlibs:Depends},
 Recommends:

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -7,7 +7,6 @@ set -eu -o pipefail
 
 # defaults
 isotype=full
-bitwidth=auto
 force=0
 retrieved_iso=0
 
@@ -31,19 +30,11 @@ if [ ${#missing_packages[@]} -ne 0 ] ; then
 fi
 
 usage() {
-  echo "Usage: $(basename "$0") [-f] [-a <32|64|96>] [-t <small|full>]"
+  echo "Usage: $(basename "$0") [-f] [-t <small|full>]"
 }
 
 while getopts ":a:t:fh" opt ; do
   case ${opt} in
-    a)
-      if [ "${OPTARG}" = 32 ] || [ "${OPTARG}" = 64 ] || [ "${OPTARG}" = 96 ] ; then
-	bitwidth="$OPTARG"
-      else
-	echo "ERROR: Invalid value '${OPTARG}'. Supported values: 32, 64, 96" >&2
-	usage >&2 ; exit 1
-      fi
-      ;;
     t)
       if [ "${OPTARG}" = "full" ] || [ "${OPTARG}" = "small" ] ; then
 	isotype="${OPTARG}"
@@ -68,22 +59,20 @@ while getopts ":a:t:fh" opt ; do
   esac
 done
 
-if [ "${bitwidth}" = auto ] ; then
-  arch="$(uname -m)"
-  case ${arch} in
-    i?86)
-      bitwidth=32
-      ;;
-    x86_64)
-      bitwidth=64
-      ;;
-    *)
-      echo "ERROR: Unknown architecture '${arch}', please specify -a flag." >&2
-      usage >&2
-      exit 1
-      ;;
-  esac
-fi
+arch="$(uname -m)"
+case ${arch} in
+  i?86)
+    bitwidth=32
+    ;;
+  x86_64)
+    bitwidth=64
+    ;;
+  *)
+    echo "ERROR: Unsupported architecture '${arch}'." >&2
+    usage >&2
+    exit 1
+    ;;
+esac
 
 echo "Finding out latest ISO image..."
 date=$(wget --quiet -O- http://download.grml.org/ | sed --regex -n 's/.*grml[0-9]{2}-(full|small)_([0-9]{4}\.[0-9]{2})\.iso.*/\2/p' | sort | tail -1)

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -113,7 +113,7 @@ isoname="grml-${grmlflavor}-${date}-${grmlarch}.iso"
 
 if [ "${force}" = "1" ] || ! [ -f "${output_directory}/${isoname}" ] ; then
   echo "Downloading Grml ISO to '${output_directory}/${isoname}'."
-  wget -O "${output_directory}/${isoname}" "http://download.grml.org/${isoname}"
+  wget -O "${output_directory}/${isoname}.tmp" "http://download.grml.org/${isoname}"
   retrieved_iso=1
 elif [ -f "${output_directory}/${isoname}" ] ; then
   echo "Found local ${output_directory}/${isoname}, skipping download (use -f to force download)."
@@ -124,14 +124,14 @@ if [ "${retrieved_iso}" = "1" ] ; then
   echo "Verifying ISO..."
   wget --quiet -O "${sig}" "http://download.grml.org/${isoname}.asc"
 
-  if ! gpgv --keyring /usr/share/keyrings/debian-keyring.gpg "${sig}" "${output_directory}/${isoname}" ; then
-    echo "ERROR: ISO file will be left in '${output_directory}/${isoname}.untrusted'." >&2
-    mv "${output_directory}/${isoname}" "${output_directory}/${isoname}.untrusted"
+  if ! gpgv --keyring /usr/share/keyrings/debian-keyring.gpg "${sig}" "${output_directory}/${isoname}.tmp" ; then
+    echo "ERROR: ISO file will be left in '${output_directory}/${isoname}.tmp'." >&2
     rm "${sig}"
     exit 1
   fi
 
   rm "${sig}"
+  mv "${output_directory}/${isoname}.tmp" "${output_directory}/${isoname}"
 
   echo "ISO file is OK."
 fi

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -6,7 +6,7 @@
 set -eu -o pipefail
 
 # defaults
-isotype=full
+grmlflavor=full
 force=0
 retrieved_iso=0
 
@@ -37,7 +37,7 @@ while getopts ":a:t:fh" opt ; do
   case ${opt} in
     t)
       if [ "${OPTARG}" = "full" ] || [ "${OPTARG}" = "small" ] ; then
-	isotype="${OPTARG}"
+	grmlflavor="${OPTARG}"
       else
 	echo "ERROR: Invalid value '${OPTARG}'. Supported values: small, full" >&2
 	usage >&2 ; exit 1
@@ -91,7 +91,7 @@ if [ -z "${diskfree}" ] ; then
   exit 1
 fi
 
-if [ "${isotype}" = "full" ] && [ "${diskfree}" -lt 1048576 ] ; then
+if [ "${grmlflavor}" = "full" ] && [ "${diskfree}" -lt 1048576 ] ; then
   if [ "${force}" = "1" ] ; then
     echo "WARN: There might not be enough free disk space in /boot, continuing anyway as requested via -f."
   else
@@ -99,7 +99,7 @@ if [ "${isotype}" = "full" ] && [ "${diskfree}" -lt 1048576 ] ; then
     echo "Note: >=1GB for grml-full recommended (use -f to force download anyway)."
     exit 1
   fi
-elif [ "${isotype}" = "small" ] && [ "${diskfree}" -lt 524288 ] ; then
+elif [ "${grmlflavor}" = "small" ] && [ "${diskfree}" -lt 524288 ] ; then
   if [ "${force}" = "1" ] ; then
     echo "WARN: There might not be enough free disk space in /boot, continuing anyway as requested via -f."
   else
@@ -109,7 +109,7 @@ elif [ "${isotype}" = "small" ] && [ "${diskfree}" -lt 524288 ] ; then
   fi
 fi
 
-isoname="grml-${isotype}-${date}-${grmlarch}.iso"
+isoname="grml-${grmlflavor}-${date}-${grmlarch}.iso"
 
 if [ "${force}" = "1" ] || ! [ -f "${output_directory}/${isoname}" ] ; then
   echo "Downloading Grml ISO to '${output_directory}/${isoname}'."

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -75,7 +75,7 @@ case ${arch} in
 esac
 
 echo "Finding out latest ISO image..."
-date=$(wget --quiet -O- http://download.grml.org/ | sed --regex -n 's/.*grml-('"$grmlflavor"')-([0-9]{4}\.[0-9]{2})-('"$grmlarch"')\.iso.*/\2/p' | sort | tail -1)
+date=$(wget --quiet -O- https://download.grml.org/ | sed --regex -n 's/.*grml-('"$grmlflavor"')-([0-9]{4}\.[0-9]{2})-('"$grmlarch"')\.iso.*/\2/p' | sort | tail -1)
 
 if [ -z "${date}" ] ; then
   echo "ERROR: Could not find out latest ISO." >&2
@@ -113,7 +113,7 @@ isoname="grml-${grmlflavor}-${date}-${grmlarch}.iso"
 
 if [ "${force}" = "1" ] || ! [ -f "${output_directory}/${isoname}" ] ; then
   echo "Downloading Grml ISO to '${output_directory}/${isoname}'."
-  wget -O "${output_directory}/${isoname}.tmp" "http://download.grml.org/${isoname}"
+  wget -O "${output_directory}/${isoname}.tmp" "https://download.grml.org/${isoname}"
   retrieved_iso=1
 elif [ -f "${output_directory}/${isoname}" ] ; then
   echo "Found local ${output_directory}/${isoname}, skipping download (use -f to force download)."
@@ -122,7 +122,7 @@ fi
 if [ "${retrieved_iso}" = "1" ] ; then
   sig="$(mktemp)"
   echo "Verifying ISO..."
-  wget --quiet -O "${sig}" "http://download.grml.org/${isoname}.asc"
+  wget --quiet -O "${sig}" "https://download.grml.org/${isoname}.asc"
 
   if ! gpgv --keyring /usr/share/keyrings/debian-keyring.gpg "${sig}" "${output_directory}/${isoname}.tmp" ; then
     echo "ERROR: ISO file will be left in '${output_directory}/${isoname}.tmp'." >&2

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -11,7 +11,7 @@ bitwidth=auto
 force=0
 retrieved_iso=0
 
-declare -A bin_to_pkg=( [update-grub]=grub-pc [wget]=wget [gpgv]=gpgv )
+declare -A bin_to_pkg=( [update-grub]=grub2-common [wget]=wget [gpgv]=gpgv )
 declare -a missing_packages=()
 for binary in "${!bin_to_pkg[@]}" ; do
   if ! which "${binary}" &>/dev/null ; then

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -75,7 +75,7 @@ case ${arch} in
 esac
 
 echo "Finding out latest ISO image..."
-date=$(wget --quiet -O- http://download.grml.org/ | sed --regex -n 's/.*grml-(full|small)-([0-9]{4}\.[0-9]{2})-('"$grmlarch"')\.iso.*/\2/p' | sort | tail -1)
+date=$(wget --quiet -O- http://download.grml.org/ | sed --regex -n 's/.*grml-('"$grmlflavor"')-([0-9]{4}\.[0-9]{2})-('"$grmlarch"')\.iso.*/\2/p' | sort | tail -1)
 
 if [ -z "${date}" ] ; then
   echo "ERROR: Could not find out latest ISO." >&2

--- a/update-grml-rescueboot
+++ b/update-grml-rescueboot
@@ -61,11 +61,11 @@ done
 
 arch="$(uname -m)"
 case ${arch} in
-  i?86)
-    bitwidth=32
+  aarch64)
+    grmlarch=arm64
     ;;
   x86_64)
-    bitwidth=64
+    grmlarch=amd64
     ;;
   *)
     echo "ERROR: Unsupported architecture '${arch}'." >&2
@@ -75,7 +75,7 @@ case ${arch} in
 esac
 
 echo "Finding out latest ISO image..."
-date=$(wget --quiet -O- http://download.grml.org/ | sed --regex -n 's/.*grml[0-9]{2}-(full|small)_([0-9]{4}\.[0-9]{2})\.iso.*/\2/p' | sort | tail -1)
+date=$(wget --quiet -O- http://download.grml.org/ | sed --regex -n 's/.*grml-(full|small)-([0-9]{4}\.[0-9]{2})-('"$grmlarch"')\.iso.*/\2/p' | sort | tail -1)
 
 if [ -z "${date}" ] ; then
   echo "ERROR: Could not find out latest ISO." >&2
@@ -109,7 +109,7 @@ elif [ "${isotype}" = "small" ] && [ "${diskfree}" -lt 524288 ] ; then
   fi
 fi
 
-isoname="grml${bitwidth}-${isotype}_${date}.iso"
+isoname="grml-${isotype}-${date}-${grmlarch}.iso"
 
 if [ "${force}" = "1" ] || ! [ -f "${output_directory}/${isoname}" ] ; then
   echo "Downloading Grml ISO to '${output_directory}/${isoname}'."


### PR DESCRIPTION
- Depend on grub2-common instead of specific grub packages. `update-grub` is in that binary, and that should make it work on arm64 too. Actually booting on arm64 is untested.
- Drops `-a` flag, instead always autodetect
- Update regex and ISO name building
- Do not leave broken ISOs around on errors
- Switch to https

Addresses Debian bug #1091702. Should have been done as part of https://github.com/grml/grml-live/issues/163

